### PR TITLE
fix: correct the css partial in the case of rendering alias pages

### DIFF
--- a/layouts/partials/hb/assets/css.html
+++ b/layouts/partials/hb/assets/css.html
@@ -1,6 +1,6 @@
 {{- $dirs := slice "" }}
 {{/* Check if there is RTL site. */}}
-{{- with where .Sites "Language.LanguageDirection" "rtl" }}
+{{- if where site.Home.Sites "Language.LanguageDirection" "rtl" }}
   {{- $dirs = $dirs | append "rtl" }}
 {{- end }}
 {{- $page := . }}


### PR DESCRIPTION
The `.Site` is not always valid in alias pages