### PR TITLE
fix: add the hb.styles parameter for defining Sass variables

### DIFF
--- a/assets/hb/scss/index.tmpl.scss
+++ b/assets/hb/scss/index.tmpl.scss
@@ -8,6 +8,7 @@
   {{- $vars := . | resources.ExecuteAsTemplate . $context }}
   {{- $vars.Content }}
 {{ end }}
+@import "hugo:vars";
 @import "variables";
 @import "../../scss/bootstrap/variables";
 @import "../../scss/bootstrap/variables-dark";

--- a/hugo.toml
+++ b/hugo.toml
@@ -28,3 +28,7 @@ weight = 1000
 css_bundle_name = "hb"
 js_bundle_name = "hb"
 logo = "/images/logo.png"
+
+[params.hb.styles]
+prefix = "hb-" # CSS variables prefix.
+# primary = "#0d6efd" # hex color codes.

--- a/layouts/partials/hb/assets/css.html
+++ b/layouts/partials/hb/assets/css.html
@@ -16,6 +16,7 @@
   {{- $options := dict
     "targetPath" (printf "css/%s%s.css" $bundle $suffix)
     "enableSourceMap" hugo.IsProduction
+    "vars" site.Params.hb.styles
   }}
   {{- if hugo.IsProduction }}
     {{- $options = merge $options (dict


### PR DESCRIPTION
```toml
[params.hb.styles]
prefix = "hb-" # CSS variables prefix.
primary = "#0d6efd" # hex color codes.
```
