### PR TITLE
feat: add the top offset mixin and CSS variable

### DIFF
--- a/assets/hb/scss/_mixins.scss
+++ b/assets/hb/scss/_mixins.scss
@@ -1,0 +1,7 @@
+@mixin top-offset($position:"") {
+  @if $position != "" {
+    position: $position;
+  }
+
+  top: var(--#{$prefix}top-offset);
+}

--- a/assets/hb/scss/_root.scss
+++ b/assets/hb/scss/_root.scss
@@ -1,0 +1,3 @@
+:root {
+  --#{$prefix}top-offset: 0;
+}

--- a/assets/hb/scss/_utilities.scss
+++ b/assets/hb/scss/_utilities.scss
@@ -1,0 +1,3 @@
+.hb-top-offset {
+  top: var(--#{$prefix}top-offset);
+}

--- a/assets/hb/scss/index.tmpl.scss
+++ b/assets/hb/scss/index.tmpl.scss
@@ -14,10 +14,12 @@
 @import "../../scss/bootstrap/variables-dark";
 
 @import "../../scss/bootstrap/maps";
+@import "mixins";
 @import "../../scss/bootstrap/mixins";
 @import "../../scss/bootstrap/utilities";
 
 // Layout & components
+@import "root";
 @import "../../scss/bootstrap/root";
 @import "../../scss/bootstrap/reboot";
 @import "../../scss/bootstrap/type";
@@ -55,6 +57,7 @@
 
 // Utilities
 @import "../../scss/bootstrap/utilities/api";
+@import "utilities";
 
 // Modules
 {{- range resources.Match "hb/modules/*/scss/index.scss" }}


### PR DESCRIPTION
The `--#{$prefix}top-offset` CSS variable is used by the `top` property with the `sticky` and `absolute` positions.

```scss
.my-sticky-element {
  @include top-offset(sticky);
}
```

You can also use the `hb-top-offset` with `position-sticky` utilities class.

```html
<div class="my-sticky-element position-sticky hb-top-offset"></div>
```

The former is useful for specified media query.