### PR TITLE
feat: add the hb.full_width parameter and page's full_width parameter

### DIFF
--- a/layouts/partials/hugopress/modules/hb/attributes/hb-main.html
+++ b/layouts/partials/hugopress/modules/hb/attributes/hb-main.html
@@ -1,3 +1,7 @@
+{{- $fullWidth := default (default false site.Params.hb.full_width) .Page.Params.full_width }}
+{{- if reflect.IsSlice $fullWidth }}
+  {{- $fullWidth = in $fullWidth .Page.Section }}
+{{- end }}
 {{- return dict
-  "class" "hb-main container"
+  "class" (cond $fullWidth "hb-main container-fluid" "hb-main container")
 }}


### PR DESCRIPTION
If page's full_width was set to true, then the current page takes full width, otherwise fallback to site's hb.full_width parameter.

The hb.full_width parameters can be a boolean value or array of string:

- boolean: true to take full width globally, default to false.
- array: the elements of array represent which first level sections will take full width, e.g. blog, docs, news and so on.