### PR TITLE
fix: allow specifying default full width for specified page types

### DIFF
--- a/layouts/partials/hugopress/modules/hb/attributes/hb-main.html
+++ b/layouts/partials/hugopress/modules/hb/attributes/hb-main.html
@@ -2,6 +2,11 @@
 {{- if reflect.IsSlice $fullWidth }}
   {{- $fullWidth = in $fullWidth .Page.Section }}
 {{- end }}
+{{- if not $fullWidth }}
+  {{- with index (default dict site.Params.hb.full_width_types) .Page.Type }}
+    {{- $fullWidth = default true .enable }}
+  {{- end }}
+{{- end }}
 {{- return dict
   "class" (cond $fullWidth "hb-main container-fluid" "hb-main container")
 }}


### PR DESCRIPTION
Takes docs module as example, with the following config, the docs layout will take full width by default.

```toml
[params.hb.full_width_types.docs]
enable = true
```