### PR TITLE
feat: add the module-exists function

### DIFF
--- a/layouts/partials/hb/functions/module-exists.html
+++ b/layouts/partials/hb/functions/module-exists.html
@@ -1,0 +1,9 @@
+{{- $exists := false }}
+{{- $module := . }}
+{{- range hugo.Deps }}
+  {{- if eq .Path $module }}
+    {{- $exists = true }}
+    {{- break }}
+  {{- end }}
+{{- end }}
+{{- return $exists }}


### PR DESCRIPTION
To check if a module exists (was imported), take `github.com/hbstack/bs-tooltip` as an example.

```
{{ $tooltip := partial "hb/functions/module-exists" "github.com/hbstack/bs-tooltip" }}
```