### PR TITLE
fix: allow specifying id attribute for blockquotes and tables

### DIFF
--- a/layouts/_default/_markup/render-blockquote-regular.html
+++ b/layouts/_default/_markup/render-blockquote-regular.html
@@ -16,7 +16,7 @@
 {{- if or (isset .Attributes "align") (isset .Attributes "caption") }}
   <figure
     class="{{ $borderClass }}{{ with .Attributes.align }} text-{{ . }}{{ end }}">
-    <blockquote class="{{ delimit $class ` ` }} mb-0">
+    <blockquote {{ with .Attributes.id }}id="{{ . }}" {{ end }}class="{{ delimit $class ` ` }} mb-0">
       {{ .Text }}
     </blockquote>
     {{- with .Attributes.caption }}
@@ -29,7 +29,7 @@
     {{- end }}
   </figure>
 {{- else }}
-  <blockquote class="{{ delimit $class ` ` }} {{ $borderClass }}">
+  <blockquote {{ with .Attributes.id }}id="{{ . }}" {{ end }}class="{{ delimit $class ` ` }} {{ $borderClass }}">
     {{ .Text }}
   </blockquote>
 {{- end }}

--- a/layouts/_default/_markup/render-blockquote-regular.html
+++ b/layouts/_default/_markup/render-blockquote-regular.html
@@ -16,7 +16,9 @@
 {{- if or (isset .Attributes "align") (isset .Attributes "caption") }}
   <figure
     class="{{ $borderClass }}{{ with .Attributes.align }} text-{{ . }}{{ end }}">
-    <blockquote {{ with .Attributes.id }}id="{{ . }}" {{ end }}class="{{ delimit $class ` ` }} mb-0">
+    <blockquote
+      {{ with .Attributes.id }}id="{{ . }}"{{ end }}
+      class="{{ delimit $class ` ` }} mb-0">
       {{ .Text }}
     </blockquote>
     {{- with .Attributes.caption }}
@@ -29,7 +31,9 @@
     {{- end }}
   </figure>
 {{- else }}
-  <blockquote {{ with .Attributes.id }}id="{{ . }}" {{ end }}class="{{ delimit $class ` ` }} {{ $borderClass }}">
+  <blockquote
+    {{ with .Attributes.id }}id="{{ . }}"{{ end }}
+    class="{{ delimit $class ` ` }} {{ $borderClass }}">
     {{ .Text }}
   </blockquote>
 {{- end }}

--- a/layouts/_default/_markup/render-table.html
+++ b/layouts/_default/_markup/render-table.html
@@ -50,7 +50,7 @@
   {{- $class = printf "%s %s" $class . }}
 {{- end }}
 <div class="table-responsive">
-  <table {{ with .Attributes.id }}id="{{ . }}" {{ end }}class="{{ $class }}"
+  <table class="{{ $class }}"
     {{- range $k, $v := .Attributes }}
       {{- if or (hasPrefix $k "_") (eq $k "class") }}
         {{- continue }}

--- a/layouts/_default/_markup/render-table.html
+++ b/layouts/_default/_markup/render-table.html
@@ -50,7 +50,7 @@
   {{- $class = printf "%s %s" $class . }}
 {{- end }}
 <div class="table-responsive">
-  <table class="{{ $class }}"
+  <table {{ with .Attributes.id }}id="{{ . }}" {{ end }}class="{{ $class }}"
     {{- range $k, $v := .Attributes }}
       {{- if or (hasPrefix $k "_") (eq $k "class") }}
         {{- continue }}


### PR DESCRIPTION
I added missing `id` attribute.

Test markdown:
```markdown
> p
{#asdf .sec}

| | |
|-|-|
|test|test2|
{.cls #tbl _thead=false}
```
Rendered result:
```html
<blockquote id="asdf" class="blockquote sec border-start ps-3 py-1 border-primary border-4">
  <p>p</p>
</blockquote>
<div class="table-responsive">
  <table id="tbl" class="table table-bordered align-middle table-hover table-striped cls">
    <tbody>
      <tr>
        <td class="text-start">test</td>
        <td class="text-start">test2</td>
      </tr>
    </tbody>
  </table>
</div>
```

I only tested with `#id` syntax, but this should also work with `id=` syntax.