### PR TITLE
fix: empty `params` passed to js.Build

### DIFF
--- a/layouts/partials/hb/assets/js.html
+++ b/layouts/partials/hb/assets/js.html
@@ -1,6 +1,6 @@
 {{- $page := . }}
 {{/* JS compile options. */}}
-{{- $params := .Site.Params.hb }}
+{{- $params := site.Params.hb }}
 {{- $bundle := default "hb"  $params.js_bundle_name }}
 {{- $targetPath := printf "js/%s.js" $bundle }}
 {{- $options := dict


### PR DESCRIPTION
Closes #275