### PR TITLE
fix: silence Dart Sass deprecations

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -36,7 +36,6 @@ js_bundle_name = "hb"
 logo = "/images/logo.png"
 color = "light" # default color mode, light or dark.
 sass_transpiler = "dartsass" # dartsass or libsass (deprecated).
-sass_silence_deprecations = ["import", "global-builtin", "color-functions"]
 
 [params.hb.styles]
 prefix = "hb-" # CSS variables prefix.

--- a/layouts/partials/hb/assets/css-resource.html
+++ b/layouts/partials/hb/assets/css-resource.html
@@ -15,18 +15,20 @@
   {{- $rtl := eq $dir "rtl" }}
   {{- $suffix := cond $rtl ".rtl" "" }}
   {{/* SCSS options. */}}
+  {{- $sassSilenceDeprecations := slice "import" "color-functions" "global-builtin" }}
   {{- $options := dict
     "transpiler" (default "dartsass" $params.hb.sass_transpiler)
     "silenceDeprecations" (
       cond
       $debug
       slice
-      (default slice $params.hb.sass_silence_deprecations)
+      $sassSilenceDeprecations
     )
     "targetPath" (printf "css/%s%s.css" $bundle $suffix)
     "enableSourceMap" hugo.IsProduction
     "vars" site.Params.hb.styles
   }}
+  {{ warnf "sass opts: %#v" $options }}
   {{- if hugo.IsProduction }}
     {{- $options = merge $options (dict
       "outputStyle" "compressed")


### PR DESCRIPTION
fix: remove the hb.sass_silence_deprecations parameter